### PR TITLE
Replace encrypted-message-body's child from <pre> to <p>

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,7 +64,7 @@ $(document).ready(function(){
 });
 
 $(document).ready(function(){
-  var encryptedTextArea = $('#encrypted-message-body pre');
+  var encryptedTextArea = $('#encrypted-message-body p');
   var encryptedText = encryptedTextArea.text();
   var encryptionKey = $('#key').text().replace(/(\r\n|\n|\r|\s)/gm,"");
   var encryptionSalt = $('#salt').text().replace(/(\r\n|\n|\r|\s)/gm,"");

--- a/app/views/messages/show.html.slim
+++ b/app/views/messages/show.html.slim
@@ -3,7 +3,7 @@
 
 #message-container
   #encrypted-message-body
-    pre
+    p
       = @message.content
 
 br


### PR DESCRIPTION
Decrypted message was being placed in a `pre` tag. So the text did not wrap:

![screen shot 2014-09-15 at 8 56 08 pm](https://cloud.githubusercontent.com/assets/6556190/4282491/f51a222e-3d59-11e4-9d0b-783ca4399dcc.png)

Fixed to a `p` tag
![screen shot 2014-09-15 at 9 27 30 pm](https://cloud.githubusercontent.com/assets/6556190/4282508/3a0fdc66-3d5a-11e4-9087-098702b4ab15.png)

Text wraps correctly
![screen shot 2014-09-15 at 8 55 44 pm](https://cloud.githubusercontent.com/assets/6556190/4282509/43f434e8-3d5a-11e4-99d6-c6e90f92e2f9.png)

Note: I’m mainly a Javascript programmer, I think I edited all the right places. And I didn’t really go through the heroku/rake stuff so this <em>could</em> break the code, but I doubt it
