### PR TITLE
Added WhatsApp and Discord to the Blocked_Bots list

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,7 +3,8 @@ class MessagesController < ApplicationController
     /facebookexternalhit/,
     /Slackbot-LinkExpanding/,
     /Twitterbot/,
-    /WhatsApp/
+    /WhatsApp/,
+    /Discord/
   ].freeze
 
   def new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,8 @@ class MessagesController < ApplicationController
   BLOCKED_BOTS = [
     /facebookexternalhit/,
     /Slackbot-LinkExpanding/,
-    /Twitterbot/
+    /Twitterbot/,
+    /WhatsApp/
   ].freeze
 
   def new


### PR DESCRIPTION
WhatsApp and Discord are trying to load a preview of a link and invalidates them, so they need to get blocked